### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This is Prologue, a simple, single page responsive site template from [HTML5 UP]
  * Set a **cover photo** for any section (not just the first), with alt text for screen readers and SEO
 * Add your **social profiles** easily in `_config.yml`.
 * Automatic search engine optimization (SEO) **meta tags** based on info you provide in `_config.yml` and frontmatter
-* **Google Analytics** built-in; just put your [Tracking ID](https://support.google.com/analytics/answer/1008080?hl=en) in `_config.yml` as `google_analytics`
 * Custom **404 page** (called 404.html; to activate, move it to your project directory).
 
 # Installation

--- a/_config.yml
+++ b/_config.yml
@@ -56,9 +56,6 @@ pinterest_url:
 slack_url:
 dribbble_url:
 
-# Google Analytics Tracking ID goes here:
-google_analytics:
-
 # The following settings are NECESSARY for the Prologue theme to run:
 theme: jekyll-theme-prologue
 collections: [sections]

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,8 +1,0 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{- site.google_analytics -}}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{- site.google_analytics -}}');
-</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,4 @@
 <head>
-  {%- if site.google_analytics and jekyll.environment == 'production' -%}
-    {%- include google_analytics.html -%}
-  {%- endif -%}
   
   <!-- Robots -->
   <meta name="robots" content="{{- page.robots | default: 'index, follow' -}}" />


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/